### PR TITLE
Etcd tls ha

### DIFF
--- a/modules/bootkube/assets.tf
+++ b/modules/bootkube/assets.tf
@@ -120,6 +120,13 @@ resource "template_dir" "bootkube_bootstrap" {
     hyperkube_image = "${var.container_images["hyperkube"]}"
     etcd_image      = "${var.container_images["etcd"]}"
 
+    # Choose the etcd endpoints to use.
+    # 1. If experimental mode is enabled (self-hosted etcd), then use
+    # var.etcd_service_ip.
+    # 2. Else if no etcd TLS certificates are provided, i.e. we bootstrap etcd
+    # nodes ourselves (using http), then use insecure http var.etcd_endpoints.
+    # 3. Else (if etcd TLS certific are provided), then use the secure https
+    # var.etcd_endpoints.
     etcd_servers = "${
       var.experimental_enabled
         ? format("https://%s:2379,https://127.0.0.1:12379", cidrhost(var.service_cidr, 15))

--- a/modules/google/etcd/dns.tf
+++ b/modules/google/etcd/dns.tf
@@ -16,29 +16,29 @@ limitations under the License.
 
 resource "google_dns_record_set" "etcd_srv_discover" {
   count        = "${var.dns_enabled ? 1 : 0}"
-  name         = "_etcd-server._tcp.${var.base_domain}."
+  name         = "${var.tls_enabled ? "_etcd-server-ssl._tcp.${var.base_domain}" : "_etcd-server._tcp.${var.base_domain}"}."
   type         = "SRV"
   managed_zone = "${var.managed_zone_name}"
-  rrdatas      = ["${format("0 0 2380 %s", google_dns_record_set.etc_a_node.name)}"]
+  rrdatas      = ["${formatlist("0 0 2380 %s", google_dns_record_set.etc_a_node.*.name)}"]
   ttl          = "300"
 }
 
 resource "google_dns_record_set" "etcd_srv_client" {
   count        = "${var.dns_enabled ? 1 : 0}"
-  name         = "_etcd-client._tcp.${var.base_domain}."
+  name         = "${var.tls_enabled ? "_etcd-client-ssl._tcp.${var.base_domain}" : "_etcd-client._tcp.${var.base_domain}"}."
   type         = "SRV"
   managed_zone = "${var.managed_zone_name}"
-  rrdatas      = ["${format("0 0 2379 %s", google_dns_record_set.etc_a_node.name)}"]
+  rrdatas      = ["${formatlist("0 0 2379 %s", google_dns_record_set.etc_a_node.*.name)}"]
   ttl          = "60"
 }
 
 resource "google_dns_record_set" "etc_a_node" {
-  count        = "${var.dns_enabled ? 1 : 0}"
+  count        = "${var.dns_enabled ? var.instance_count : 0}"
   type         = "A"
   ttl          = "60"
   managed_zone = "${var.managed_zone_name}"
-  name         = "${var.cluster_name}-etcd.${var.base_domain}."
-  rrdatas      = ["${google_compute_instance.etcd-node.network_interface.0.address}"]
+  name         = "${var.cluster_name}-etcd-${count.index}.${var.base_domain}."
+  rrdatas      = ["${google_compute_instance.etcd-node.*.network_interface.0.address[count.index]}"]
 }
 
 # vim: ts=2:sw=2:sts=2:et:ai

--- a/modules/google/etcd/etcd.tf
+++ b/modules/google/etcd/etcd.tf
@@ -15,10 +15,11 @@ limitations under the License.
 */
 
 resource "google_compute_instance" "etcd-node" {
-  name           = "${var.cluster_name}-etcd"
+  name           = "${var.cluster_name}-etcd-${count.index}"
+  count          = "${length(var.external_endpoints) == 0 ? var.instance_count : 0}"
   machine_type   = "${var.machine_type}"
   can_ip_forward = false
-  zone           = "${element(var.zone_list,0)}" # pick first zone
+  zone           = "${element(var.zone_list, count.index)}"
 
   disk {
     image = "coreos-${var.cl_channel}"
@@ -34,10 +35,10 @@ resource "google_compute_instance" "etcd-node" {
     }
   }
 
-  tags = ["tectonic-masters"]
+  tags = ["tectonic-etcd"]
 
   metadata = {
-    user-data = "${data.ignition_config.etcd.rendered}"
+    user-data = "${data.ignition_config.etcd.*.rendered[count.index]}"
   }
 
   service_account {

--- a/modules/google/etcd/ignition.tf
+++ b/modules/google/etcd/ignition.tf
@@ -1,37 +1,152 @@
 data "ignition_config" "etcd" {
+  count = "${length(var.external_endpoints) == 0 ? var.instance_count : 0}"
+
   systemd = [
-    "${data.ignition_systemd_unit.locksmithd.id}",
-    "${data.ignition_systemd_unit.etcd3.id}",
+    "${data.ignition_systemd_unit.locksmithd.*.id[count.index]}",
+    "${data.ignition_systemd_unit.etcd3.*.id[count.index]}",
   ]
 
   files = [
-    "${data.ignition_file.node_hostname.id}",
+    "${data.ignition_file.node_hostname.*.id[count.index]}",
+    "${data.ignition_file.etcd_ca.id}",
+    "${data.ignition_file.etcd_server_crt.id}",
+    "${data.ignition_file.etcd_server_key.id}",
+    "${data.ignition_file.etcd_client_crt.id}",
+    "${data.ignition_file.etcd_client_key.id}",
+    "${data.ignition_file.etcd_peer_crt.id}",
+    "${data.ignition_file.etcd_peer_key.id}",
   ]
 }
 
 data "ignition_file" "node_hostname" {
+  count      = "${length(var.external_endpoints) == 0 ? var.instance_count : 0}"
   path       = "/etc/hostname"
   mode       = 0644
   filesystem = "root"
 
   content {
-    content = "${var.cluster_name}-etcd.${var.base_domain}"
+    content = "${var.cluster_name}-etcd-${count.index}.${var.base_domain}"
+  }
+}
+
+data "ignition_file" "etcd_ca" {
+  count = "${length(var.external_endpoints) == 0 ? var.instance_count > 0 ? 1 : 0 : 0}"
+
+  path       = "/etc/ssl/etcd/ca.crt"
+  mode       = 0644
+  uid        = 232
+  gid        = 232
+  filesystem = "root"
+
+  content {
+    content = "${var.tls_ca_crt_pem}"
+  }
+}
+
+data "ignition_file" "etcd_client_key" {
+  path       = "/etc/ssl/etcd/client.key"
+  mode       = 0400
+  uid        = 0
+  gid        = 0
+  filesystem = "root"
+
+  content {
+    content = "${var.tls_client_key_pem}"
+  }
+}
+
+data "ignition_file" "etcd_client_crt" {
+  path       = "/etc/ssl/etcd/client.crt"
+  mode       = 0400
+  uid        = 0
+  gid        = 0
+  filesystem = "root"
+
+  content {
+    content = "${var.tls_client_crt_pem}"
+  }
+}
+
+data "ignition_file" "etcd_server_key" {
+  count = "${length(var.external_endpoints) == 0 ? var.instance_count > 0 ? 1 : 0 : 0}"
+
+  path       = "/etc/ssl/etcd/server.key"
+  mode       = 0400
+  uid        = 232
+  gid        = 232
+  filesystem = "root"
+
+  content {
+    content = "${var.tls_server_key_pem}"
+  }
+}
+
+data "ignition_file" "etcd_server_crt" {
+  count = "${length(var.external_endpoints) == 0 ? var.instance_count > 0 ? 1 : 0 : 0}"
+
+  path       = "/etc/ssl/etcd/server.crt"
+  mode       = 0400
+  uid        = 232
+  gid        = 232
+  filesystem = "root"
+
+  content {
+    content = "${var.tls_server_crt_pem}"
+  }
+}
+
+data "ignition_file" "etcd_peer_key" {
+  count = "${length(var.external_endpoints) == 0 ? var.instance_count > 0 ? 1 : 0 : 0}"
+
+  path       = "/etc/ssl/etcd/peer.key"
+  mode       = 0400
+  uid        = 232
+  gid        = 232
+  filesystem = "root"
+
+  content {
+    content = "${var.tls_peer_key_pem}"
+  }
+}
+
+data "ignition_file" "etcd_peer_crt" {
+  count = "${length(var.external_endpoints) == 0 ? var.instance_count > 0 ? 1 : 0 : 0}"
+
+  path       = "/etc/ssl/etcd/peer.crt"
+  mode       = 0400
+  uid        = 232
+  gid        = 232
+  filesystem = "root"
+
+  content {
+    content = "${var.tls_peer_crt_pem}"
   }
 }
 
 data "ignition_systemd_unit" "locksmithd" {
+  count = "${length(var.external_endpoints) == 0 ? var.instance_count : 0}"
+
   name   = "locksmithd.service"
   enable = true
 
   dropin = [
     {
-      name    = "40-etcd-lock.conf"
-      content = "[Service]\nEnvironment=REBOOT_STRATEGY=etcd-lock\n"
+      name = "40-etcd-lock.conf"
+
+      content = <<EOF
+[Service]
+Environment=REBOOT_STRATEGY=etcd-lock
+${var.tls_enabled ? "Environment=\"LOCKSMITHD_ETCD_CAFILE=/etc/ssl/etcd/ca.crt\"" : ""}
+${var.tls_enabled ? "Environment=\"LOCKSMITHD_ETCD_KEYFILE=/etc/ssl/etcd/client.key\"" : ""}
+${var.tls_enabled ? "Environment=\"LOCKSMITHD_ETCD_CERTFILE=/etc/ssl/etcd/client.crt\"" : ""}
+Environment="LOCKSMITHD_ENDPOINT=${var.tls_enabled ? "https" : "http"}://${var.cluster_name}-etcd-${count.index}.${var.base_domain}:2379"
+EOF
     },
   ]
 }
 
 data "ignition_systemd_unit" "etcd3" {
+  count  = "${length(var.external_endpoints) == 0 ? var.instance_count : 0}"
   name   = "etcd-member.service"
   enable = true
 
@@ -42,12 +157,19 @@ data "ignition_systemd_unit" "etcd3" {
       content = <<EOF
 [Service]
 Environment="ETCD_IMAGE=${var.container_image}"
+Environment="RKT_RUN_ARGS=--volume etcd-ssl,kind=host,source=/etc/ssl/etcd \
+  --mount volume=etcd-ssl,target=/etc/ssl/etcd"
 ExecStart=
 ExecStart=/usr/lib/coreos/etcd-wrapper \
   --name=etcd \
-  --advertise-client-urls=http://${var.cluster_name}-etcd:2379 \
-  --listen-client-urls=http://0.0.0.0:2379 \
-  --listen-peer-urls=http://0.0.0.0:2380
+  --discovery-srv=${var.base_domain} \
+  --advertise-client-urls=${var.tls_enabled ? "https" : "http"}://${var.cluster_name}-etcd-${count.index}.${var.base_domain}:2379 \
+  ${var.tls_enabled
+    ? "--cert-file=/etc/ssl/etcd/server.crt --key-file=/etc/ssl/etcd/server.key --peer-cert-file=/etc/ssl/etcd/peer.crt --peer-key-file=/etc/ssl/etcd/peer.key --peer-trusted-ca-file=/etc/ssl/etcd/ca.crt --peer-client-cert-auth=true"
+    : ""} \
+  --initial-advertise-peer-urls=${var.tls_enabled ? "https" : "http"}://${var.cluster_name}-etcd-${count.index}.${var.base_domain}:2380 \
+  --listen-client-urls=${var.tls_enabled ? "https" : "http"}://0.0.0.0:2379 \
+  --listen-peer-urls=${var.tls_enabled ? "https" : "http"}://0.0.0.0:2380
 EOF
     },
   ]

--- a/modules/google/etcd/outputs.tf
+++ b/modules/google/etcd/outputs.tf
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 output "etcd_ip" {
-  value = "${google_compute_instance.etcd-node.network_interface.0.address}"
+  value = ["${split(",", length(var.external_endpoints) == 0 ? join(",", google_dns_record_set.etc_a_node.*.name) : join(",", var.external_endpoints))}"]
 }
 
 # vim: ts=2:sw=2:sts=2:et:ai

--- a/modules/google/etcd/variables.tf
+++ b/modules/google/etcd/variables.tf
@@ -14,6 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+variable "external_endpoints" {
+  type = "list"
+}
+
+variable "instance_count" {
+  type = "string"
+}
+
 variable "dns_enabled" {
   type = "string"
 }
@@ -58,6 +66,38 @@ variable "disk_type" {
 variable "disk_size" {
   type        = "string"
   description = "The size of the volume in gigabytes for the root block device."
+}
+
+variable "tls_enabled" {
+  default = false
+}
+
+variable "tls_ca_crt_pem" {
+  default = ""
+}
+
+variable "tls_client_key_pem" {
+  default = ""
+}
+
+variable "tls_client_crt_pem" {
+  default = ""
+}
+
+variable "tls_server_key_pem" {
+  default = ""
+}
+
+variable "tls_server_crt_pem" {
+  default = ""
+}
+
+variable "tls_peer_key_pem" {
+  default = ""
+}
+
+variable "tls_peer_crt_pem" {
+  default = ""
 }
 
 # vim: ts=2:sw=2:sts=2:et:ai

--- a/modules/google/master-igm/master.tf
+++ b/modules/google/master-igm/master.tf
@@ -85,22 +85,5 @@ resource "google_compute_instance_group_manager" "tectonic-master-igm" {
   base_instance_name = "mstr"
 }
 
-resource "google_compute_autoscaler" "tectonic-master-as" {
-  #count  = "${length(var.zone_list)}"
-  name   = "tectonic-master-as"
-  zone   = "${element(var.zone_list, 0)}"                                                          # 0 -> count.index
-  target = "${google_compute_instance_group_manager.tectonic-master-igm.*.self_link[count.index]}"
-
-  autoscaling_policy = {
-    max_replicas    = "${var.max_masters}"
-    min_replicas    = "${var.instance_count}"
-    cooldown_period = 60
-
-    cpu_utilization {
-      target = 0.25
-    }
-  }
-}
-
 # vim: ts=2:sw=2:sts=2:et:ai
 

--- a/modules/google/network/firewall-etcd.tf
+++ b/modules/google/network/firewall-etcd.tf
@@ -1,0 +1,30 @@
+resource "google_compute_firewall" "etcd-ingress" {
+  name    = "etcd-ingress"
+  network = "${google_compute_network.tectonic-network.name}"
+
+  # ICMP
+  allow {
+    protocol = "icmp"
+  }
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"] # ssh
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["tectonic-etcd"]
+}
+
+resource "google_compute_firewall" "etcd" {
+  name    = "etcd"
+  network = "${google_compute_network.tectonic-network.name}"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["2379", "2380", "12379"] # etcd and bootstrap-etcd
+  }
+
+  source_tags = ["tectonic-etcd"]
+  target_tags = ["tectonic-etcd"]
+}

--- a/modules/google/network/firewall-master.tf
+++ b/modules/google/network/firewall-master.tf
@@ -78,7 +78,7 @@ resource "google_compute_firewall" "master-ingress-etcd" {
   }
 
   source_tags = ["tectonic-masters"]
-  target_tags = ["tectonic-masters"]
+  target_tags = ["tectonic-masters", "tectonic-etcd"]
 }
 
 resource "google_compute_firewall" "master-ingress-services" {

--- a/modules/google/worker-igm/worker.tf
+++ b/modules/google/worker-igm/worker.tf
@@ -55,22 +55,5 @@ resource "google_compute_instance_group_manager" "tectonic-worker-igm" {
   base_instance_name = "wrkr"
 }
 
-resource "google_compute_autoscaler" "tectonic-worker-as" {
-  count  = "${length(var.zone_list)}"
-  name   = "tectonic-worker-as"
-  zone   = "${google_compute_instance_group_manager.tectonic-worker-igm.*.zone[count.index]}"
-  target = "${google_compute_instance_group_manager.tectonic-worker-igm.*.self_link[count.index]}"
-
-  autoscaling_policy = {
-    max_replicas    = "${var.max_workers}"
-    min_replicas    = "${var.instance_count}"
-    cooldown_period = 60
-
-    cpu_utilization {
-      target = 0.25
-    }
-  }
-}
-
 # vim: ts=2:sw=2:sts=2:et:ai
 

--- a/platforms/google/main.tf
+++ b/platforms/google/main.tf
@@ -68,8 +68,8 @@ module "network" {
 }
 
 module "etcd" {
-  source = "../../modules/google/etcd"
-
+  source            = "../../modules/google/etcd"
+  instance_count    = "${var.tectonic_experimental ? 0 : var.tectonic_etcd_count > 0 ? var.tectonic_etcd_count : length(var.tectonic_gcp_zones) == 5 ? 5 : 3}"
   zone_list         = "${var.tectonic_gcp_zones}"
   machine_type      = "${var.tectonic_gcp_etcd_gce_type}"
   managed_zone_name = "${var.google_managedzone_name}"
@@ -84,6 +84,16 @@ module "etcd" {
 
   master_subnetwork_name = "${module.network.master_subnetwork_name}"
   dns_enabled            = "${!var.tectonic_experimental && length(compact(var.tectonic_etcd_servers)) == 0}"
+  external_endpoints     = ["${compact(var.tectonic_etcd_servers)}"]
+
+  tls_enabled        = "${var.tectonic_etcd_tls_enabled}"
+  tls_ca_crt_pem     = "${module.bootkube.etcd_ca_crt_pem}"
+  tls_server_crt_pem = "${module.bootkube.etcd_server_crt_pem}"
+  tls_server_key_pem = "${module.bootkube.etcd_server_key_pem}"
+  tls_client_crt_pem = "${module.bootkube.etcd_client_crt_pem}"
+  tls_client_key_pem = "${module.bootkube.etcd_client_key_pem}"
+  tls_peer_crt_pem   = "${module.bootkube.etcd_peer_crt_pem}"
+  tls_peer_key_pem   = "${module.bootkube.etcd_peer_key_pem}"
 }
 
 module "masters" {


### PR DESCRIPTION
This adds TLS and HA multi-node Support for etcd. Basic SDN is set with flannel-vxlan module.
It basically brings a translation from the aws/etcd module into the gcp world.

Test from etcd machine:
```etcdctl --ca-file=/etc/ssl/etcd/ca.crt --endpoint https://domain:2379 member list```

Test from Kube master machine:
```etcdctl --ca-file=/opt/tectonic/tls/etcd-client-ca.crt --endpoint https://domain:2379 cluster-health```

The Cluster can be recreated consistently with 3 etcd masters.
